### PR TITLE
Change remote WASI branch as per WASI SG decision

### DIFF
--- a/README.md
+++ b/README.md
@@ -2453,4 +2453,4 @@ Possible values:
 
 [WASI]: https://github.com/WebAssembly/WASI
 [libuv]: https://github.com/libuv/libuv
-[snapshot_1]: https://github.com/WebAssembly/WASI/blob/master/phases/snapshot/docs.md
+[snapshot_1]: https://github.com/WebAssembly/WASI/blob/main/phases/snapshot/docs.md

--- a/include/wasi_types.h
+++ b/include/wasi_types.h
@@ -4,7 +4,7 @@
 #include <stddef.h>
 #include <stdint.h>
 
-/* API: https://github.com/WebAssembly/WASI/blob/master/phases/snapshot/docs.md */
+/* API: https://github.com/WebAssembly/WASI/blob/main/phases/snapshot/docs.md */
 
 typedef uint32_t uvwasi_size_t;
 


### PR DESCRIPTION
The URL in `README.md` is usually not visible as plaintext, but the reference in the header file is.

Refs: https://github.com/WebAssembly/WASI/issues/290