### PR TITLE
chore: update CI Image

### DIFF
--- a/.github/workflows/Android.yml
+++ b/.github/workflows/Android.yml
@@ -5,7 +5,7 @@ on: [push, pull_request]
 jobs:
   build-android:
     runs-on: ubuntu-latest
-    container: reactnativecommunity/react-native-android:2020-5-20
+    container: reactnativecommunity/react-native-android:3.2
     steps:
       - uses: actions/checkout@v2
       - name: Envinfo
@@ -15,5 +15,5 @@ jobs:
         run: |
           apt update && apt install python3-pip -y && pip3 install cmake
           mkdir build && cd build
-          cmake -DCMAKE_TOOLCHAIN_FILE=$ANDROID_HOME/ndk/20.0.5594570/build/cmake/android.toolchain.cmake -DCMAKE_BUILD_TYPE=Release -DANDROID_ABI="arm64-v8a" -DANDROID_PLATFORM=android-21 ..
+          cmake -DCMAKE_TOOLCHAIN_FILE=$ANDROID_NDK/build/cmake/android.toolchain.cmake -DCMAKE_BUILD_TYPE=Release -DANDROID_ABI="arm64-v8a" -DANDROID_PLATFORM=android-21 ..
           cmake --build .


### PR DESCRIPTION
Yarn signature changes result in old image `apt update` will fail.