### PR TITLE
Handle NULL pointers in uvwasi_destroy consistently

### DIFF
--- a/src/uvwasi.c
+++ b/src/uvwasi.c
@@ -127,6 +127,9 @@ void* uvwasi__malloc(const uvwasi_t* uvwasi, size_t size) {
 }
 
 void uvwasi__free(const uvwasi_t* uvwasi, void* ptr) {
+  if (ptr == NULL)
+    return;
+
   uvwasi->allocator->free(ptr, uvwasi->allocator->mem_user_data);
 }
 

--- a/test/test-wasi-destroy-without-init.c
+++ b/test/test-wasi-destroy-without-init.c
@@ -1,0 +1,10 @@
+#include <assert.h>
+#include <stdlib.h>
+#include <string.h>
+#include "uvwasi.h"
+
+int main(void) {
+  uvwasi_t uvwasi = {0};
+  uvwasi_destroy(&uvwasi);
+  return 0;
+}


### PR DESCRIPTION
`uvwasi_destroy` currently handles the case when NULL is passed as `uvwasi`
https://github.com/nodejs/uvwasi/blob/adda15515cbb5a478d0ddb85602d987278a43384/src/uvwasi.c#L372-L373
and also when `uvwasi->fds` is NULL
https://github.com/nodejs/uvwasi/blob/adda15515cbb5a478d0ddb85602d987278a43384/src/fd_table.c#L231-L232
but not the case when `uvwasi->allocator` is NULL.

I suggest for consistency to handle fully zeroed-out `uvwasi` passed to `uvwasi_destroy`. That would simplify client-side in that you wouldn't need to check whether `uvwasi_init` finished successfully when you call `uvwasi_destroy`.

P.S. Not sure if it would also make sense to add `uvwasi->allocator = NULL;` to `uvwasi_destroy`. 