### PR TITLE
Clarify top-level purpose of uvwasi in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,29 @@
 # uvwasi
 
-`uvwasi` implements the [WASI][] system call API. Under the hood, `uvwasi`
+`uvwasi` implements the [WASI][] system call API, so that WebAssembly
+runtimes can easily implement WASI calls.  Under the hood, `uvwasi`
 leverages [libuv][] where possible for maximum portability.
+
+                                  |
+    WebAssembly code              |      WebAssembly application code
+                                  |                 |
+                                  |                 v
+                                  | WASI syscalls (inserted by compiler toolchain)
+                                  |                 |
+    ------------------------------+                 |
+                                  |                 v
+    WebAssembly runtime (Node.js) |    uvwasi (implementation of WASI)
+                                  |                 |
+                                  |                 v
+                                  |               libuv
+                                  |                 |
+                                  |                 v
+                                  |        platform-specific calls
+                                  | 
+
+*(Hence uvwasi isn't for making C-programs-that-use-libuv-APIs execute on
+WASI runtimes.  That would either be a new platform added by libuv, or done
+through POSIX emulation by the Emscripten or Wasi-Sdk toolchains.)*
 
 ## Building Locally
 


### PR DESCRIPTION
This adds a diagram provided by @tniessen to the README, which I believe is very helpful (at least it would have saved me quite some time, puzzling over why uvwasi wasn't what I hoped it would be.)

(I believe it's also good to clarify that uvwasi is not useful to people with libuv-based code who wish to run that code in WASI containers.  I'm sure many in that situation would type in "libuv" and "wasi" and get here as the top hit.)