### PR TITLE
Add support for single argument UVWASI_DEBUG

### DIFF
--- a/src/debug.h
+++ b/src/debug.h
@@ -6,8 +6,8 @@
 # define __STDC_FORMAT_MACROS
 #endif
 # include <inttypes.h>
-# define UVWASI_DEBUG(fmt, ...)                                                      \
-    do { fprintf(stderr, fmt, __VA_ARGS__); } while (0)
+# define UVWASI_DEBUG(...)                                                     \
+    do { fprintf(stderr, __VA_ARGS__); } while (0)
 #else
 # define UVWASI_DEBUG(fmt, ...)
 #endif

--- a/src/debug.h
+++ b/src/debug.h
@@ -6,7 +6,7 @@
 # define __STDC_FORMAT_MACROS
 #endif
 # include <inttypes.h>
-# define UVWASI_DEBUG(...)                                                           \
+# define UVWASI_DEBUG(...)                                                    \
     do { fprintf(stderr, __VA_ARGS__); } while (0)
 #else
 # define UVWASI_DEBUG(fmt, ...)

--- a/src/debug.h
+++ b/src/debug.h
@@ -6,7 +6,7 @@
 # define __STDC_FORMAT_MACROS
 #endif
 # include <inttypes.h>
-# define UVWASI_DEBUG(...)                                                     \
+# define UVWASI_DEBUG(...)                                                           \
     do { fprintf(stderr, __VA_ARGS__); } while (0)
 #else
 # define UVWASI_DEBUG(fmt, ...)


### PR DESCRIPTION
This commit updates the UVWASI_DEBUG macro to accept a single format argument, one without any format specifiers in it and hence no following arguments. For example:
```c
    UVWASI_DEBUG("some log message...\n");
```
This will currently result in the following compiler error:
```console
/uvwasi/src/uvwasi.c: In function ‘uvwasi_fd_readdir’: /uvwasi/src/debug.h:10:42: error:
expected expression before ‘)’ token
   10 |     do { fprintf(stderr, fmt, __VA_ARGS__); } while (0)
      |                                          ^
/uvwasi/src/uvwasi.c:1303:3: note: in expansion of macro ‘UVWASI_DEBUG’
 1303 |   UVWASI_DEBUG("some log message...\n");
```
This change in this commit allows the above kind of log statements.