### PR TITLE
fix: libuv can return UV_FILE or UV_TTY for FILE_TYPE_CHAR handles

### DIFF
--- a/src/uv_mapping.c
+++ b/src/uv_mapping.c
@@ -251,8 +251,13 @@ uvwasi_errno_t uvwasi__get_filetype_by_fd(uv_file fd, uvwasi_filetype_t* type) {
   if (r != 0) {
     uv_fs_req_cleanup(&req);
 
-    /* Windows can't stat a TTY. */
-    if (uv_guess_handle(fd) == UV_TTY) {
+    int guess;
+    /*
+      Windows can't stat a FILE_TYPE_CHAR, which is guessed
+      as UV_TTY in "ConsoleMode" or UV_FILE otherwise.
+    */
+    guess = uv_guess_handle(fd);
+    if (guess == UV_TTY || guess == UV_FILE) {
       *type = UVWASI_FILETYPE_CHARACTER_DEVICE;
       return UVWASI_ESUCCESS;
     }

--- a/src/uv_mapping.c
+++ b/src/uv_mapping.c
@@ -251,7 +251,7 @@ uvwasi_errno_t uvwasi__get_filetype_by_fd(uv_file fd, uvwasi_filetype_t* type) {
   if (r != 0) {
     uv_fs_req_cleanup(&req);
 
-    int guess;
+    uv_handle_type guess;
     /*
       Windows can't stat a FILE_TYPE_CHAR, which is guessed
       as UV_TTY in "ConsoleMode" or UV_FILE otherwise.


### PR DESCRIPTION
When uvwasi is used on Windows, it might be used in non-"ConsoleMode" and the `uv_guess_handle` function can return two different values for `FILE_TYPE_CHAR` because of that difference, see https://github.com/libuv/libuv/blob/v1.x/src/win/handle.c#L42-L47

This function can also return `UV_FILE` in the case of `FILE_TYPE_DISK` but I assume that a disk file will properly stat and there isn't a good way to figure out which one is being returned.

This fixes #157 (took me about a month of debugging)