### PR TITLE
v0.0.15

### DIFF
--- a/include/uvwasi.h
+++ b/include/uvwasi.h
@@ -10,7 +10,7 @@ extern "C" {
 
 #define UVWASI_VERSION_MAJOR 0
 #define UVWASI_VERSION_MINOR 0
-#define UVWASI_VERSION_PATCH 14
+#define UVWASI_VERSION_PATCH 15
 #define UVWASI_VERSION_HEX ((UVWASI_VERSION_MAJOR << 16) | \
                             (UVWASI_VERSION_MINOR <<  8) | \
                             (UVWASI_VERSION_PATCH))


### PR DESCRIPTION
Notable changes:

- Use `GetThreadTimes()` on Windows for `CLOCK_THREAD_CPUTIME_ID`.
- Increase the precision of the process and thread clocks on Windows.