### PR TITLE
add stub for sock_accept

### DIFF
--- a/include/uvwasi.h
+++ b/include/uvwasi.h
@@ -251,6 +251,10 @@ uvwasi_errno_t uvwasi_random_get(uvwasi_t* uvwasi,
                                  void* buf,
                                  uvwasi_size_t buf_len);
 uvwasi_errno_t uvwasi_sched_yield(uvwasi_t* uvwasi);
+uvwasi_errno_t uvwasi_sock_accept(uvwasi_t* uvwasi,
+                                  uvwasi_fd_t sock,
+                                  uvwasi_fdflags_t flags,
+                                  uvwasi_fd_t* fd);
 uvwasi_errno_t uvwasi_sock_recv(uvwasi_t* uvwasi,
                                 uvwasi_fd_t sock,
                                 const uvwasi_iovec_t* ri_data,
@@ -267,10 +271,6 @@ uvwasi_errno_t uvwasi_sock_send(uvwasi_t* uvwasi,
 uvwasi_errno_t uvwasi_sock_shutdown(uvwasi_t* uvwasi,
                                     uvwasi_fd_t sock,
                                     uvwasi_sdflags_t how);
-uvwasi_errno_t uvwasi_sock_accept(uvwasi_t* uvwasi,
-                                  uvwasi_fd_t sock,
-                                  uvwasi_fdflags_t flags,
-                                  uvwasi_fd_t* fd);
 
 #ifdef __cplusplus
 }

--- a/include/uvwasi.h
+++ b/include/uvwasi.h
@@ -267,6 +267,10 @@ uvwasi_errno_t uvwasi_sock_send(uvwasi_t* uvwasi,
 uvwasi_errno_t uvwasi_sock_shutdown(uvwasi_t* uvwasi,
                                     uvwasi_fd_t sock,
                                     uvwasi_sdflags_t how);
+uvwasi_errno_t uvwasi_sock_accept(uvwasi_t* uvwasi,
+                                  uvwasi_fd_t sock,
+                                  uvwasi_fdflags_t flags,
+                                  uvwasi_fd_t* fd);
 
 #ifdef __cplusplus
 }

--- a/include/wasi_types.h
+++ b/include/wasi_types.h
@@ -214,6 +214,7 @@ typedef uint64_t uvwasi_rights_t;                /* Bitfield */
 #define UVWASI_RIGHT_PATH_UNLINK_FILE        (1 << 26)
 #define UVWASI_RIGHT_POLL_FD_READWRITE       (1 << 27)
 #define UVWASI_RIGHT_SOCK_SHUTDOWN           (1 << 28)
+#define UVWASI_RIGHT_SOCK_ACCEPT             (1 << 29)
 
 typedef uint16_t uvwasi_roflags_t;               /* Bitfield */
 #define UVWASI_SOCK_RECV_DATA_TRUNCATED (1 << 0)

--- a/src/uvwasi.c
+++ b/src/uvwasi.c
@@ -2561,8 +2561,7 @@ uvwasi_errno_t uvwasi_sock_accept(uvwasi_t* uvwasi,
                                   uvwasi_fd_t sock,
                                   uvwasi_fdflags_t flags,
                                   uvwasi_fd_t* fd) {
-  /* TODO(mhdawson): Waiting to implement, pending
-                    https://github.com/WebAssembly/WASI/issues/4 */
+  /* TODO(mhdawson): Needs implementation */
   UVWASI_DEBUG("uvwasi_sock_accept(uvwasi=%p, unimplemented)\n", uvwasi);
   return UVWASI_ENOTSUP;
 };

--- a/src/uvwasi.c
+++ b/src/uvwasi.c
@@ -2557,6 +2557,16 @@ uvwasi_errno_t uvwasi_sock_shutdown(uvwasi_t* uvwasi,
   return UVWASI_ENOTSUP;
 }
 
+uvwasi_errno_t uvwasi_sock_accept(uvwasi_t* uvwasi,
+                                  uvwasi_fd_t sock,
+                                  uvwasi_fdflags_t flags,
+                                  uvwasi_fd_t* fd) {
+  /* TODO(mhdawson): Waiting to implement, pending
+                    https://github.com/WebAssembly/WASI/issues/4 */
+  UVWASI_DEBUG("uvwasi_sock_accept(uvwasi=%p, unimplemented)\n", uvwasi);
+  return UVWASI_ENOTSUP;
+};
+
 
 const char* uvwasi_embedder_err_code_to_string(uvwasi_errno_t code) {
   switch (code) {

--- a/src/wasi_rights.h
+++ b/src/wasi_rights.h
@@ -31,7 +31,8 @@
                             UVWASI_RIGHT_PATH_UNLINK_FILE |                   \
                             UVWASI_RIGHT_PATH_REMOVE_DIRECTORY |              \
                             UVWASI_RIGHT_POLL_FD_READWRITE |                  \
-                            UVWASI_RIGHT_SOCK_SHUTDOWN)
+                            UVWASI_RIGHT_SOCK_SHUTDOWN |                      \
+                            UVWASI_RIGHT_SOCK_ACCEPT)
 
 #define UVWASI__RIGHTS_BLOCK_DEVICE_BASE UVWASI__RIGHTS_ALL
 #define UVWASI__RIGHTS_BLOCK_DEVICE_INHERITING UVWASI__RIGHTS_ALL

--- a/test/test-enotsup-apis.c
+++ b/test/test-enotsup-apis.c
@@ -6,6 +6,7 @@ int main(void) {
   assert(UVWASI_ENOTSUP == uvwasi_sock_recv(NULL, 0, NULL, 0, 0, NULL, NULL));
   assert(UVWASI_ENOTSUP == uvwasi_sock_send(NULL, 0, NULL, 0, 0, NULL));
   assert(UVWASI_ENOTSUP == uvwasi_sock_shutdown(NULL, 0, 0));
+  assert(UVWASI_ENOTSUP == uvwasi_sock_accept(NULL, 0, 0, NULL));
 
   return 0;
 }


### PR DESCRIPTION
add the stub for sock_accept so that we have
stubs for all method in the current version of
snapshot 1. sock_accept was added later after
snapshot 1 was first documented.

Signed-off-by: Michael Dawson <mdawson@devrus.com>