### PR TITLE
fix: Return correct length of string in fd_prestat_get

### DIFF
--- a/src/uvwasi.c
+++ b/src/uvwasi.c
@@ -1122,7 +1122,7 @@ uvwasi_errno_t uvwasi_fd_prestat_get(uvwasi_t* uvwasi,
   }
 
   buf->pr_type = UVWASI_PREOPENTYPE_DIR;
-  buf->u.dir.pr_name_len = strlen(wrap->path) + 1;
+  buf->u.dir.pr_name_len = strlen(wrap->path);
   err = UVWASI_ESUCCESS;
 exit:
   uv_mutex_unlock(&wrap->mutex);
@@ -1156,7 +1156,7 @@ uvwasi_errno_t uvwasi_fd_prestat_dir_name(uvwasi_t* uvwasi,
     goto exit;
   }
 
-  size = strlen(wrap->path) + 1;
+  size = strlen(wrap->path);
   if (size > (size_t) path_len) {
     err = UVWASI_ENOBUFS;
     goto exit;

--- a/test/test-fd-prestat-dir-name.c
+++ b/test/test-fd-prestat-dir-name.c
@@ -34,16 +34,17 @@ int main(void) {
   assert(err == 0);
   assert(prestat.pr_type == UVWASI_PREOPENTYPE_DIR);
   assert(prestat.u.dir.pr_name_len ==
-         strlen(init_options.preopens[0].mapped_path) + 1);
+         strlen(init_options.preopens[0].mapped_path));
 
   /* Verify uvwasi_fd_prestat_dir_name(). */
-  prestat_buf_size = prestat.u.dir.pr_name_len + 1;
-  prestat_buf = malloc(prestat_buf_size);
+  prestat_buf_size = prestat.u.dir.pr_name_len;
+  prestat_buf = malloc(prestat_buf_size + 1);
   assert(prestat_buf != NULL);
   err = uvwasi_fd_prestat_dir_name(&uvwasi,
                                    3,
                                    prestat_buf,
                                    prestat_buf_size);
+  prestat_buf[prestat_buf_size] = '\0';
   assert(err == 0);
   assert(strcmp(prestat_buf, init_options.preopens[0].mapped_path) == 0);
   free(prestat_buf);


### PR DESCRIPTION
Previously, `fd_prestat_get` would return the length of the directory name + 1, for the null terminator. This isn't quite right, as WASI strings are not null-terminated, and instead always operate in terms of a pointer and a size.

If a consumer of `fd_prestat_get` with `fd_prestat_dir_name` wants this value as a null-terminated string, they need to null-terminate it themselves, which I reflected in the tests.

This probably hasn't been noticed before because if the consumer of uvwasi uses null-terminated strings, functions like `strlen` will still report the correct value, but this isn't the case for languages that don't null-terminate strings, with null being a valid string character.

This could be considered a breaking fix if someone relied on uvwasi reporting and subsequently copying over the null byte, but I'll leave that decision to @cjihrig.