### PR TITLE
feat!: Allow project to be installable

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -52,6 +52,7 @@ Mkfile.old
 dkms.conf
 
 out/
+install/
 
 .idea/
 cmake-build-debug/

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,5 +1,10 @@
 cmake_minimum_required(VERSION 3.11)
-project (uvwasi LANGUAGES C)
+project (
+    uvwasi
+    DESCRIPTION "WASI syscall API built atop libuv"
+    VERSION 0.0.18
+    LANGUAGES C
+)
 
 # Point CMake at any custom modules we may ship
 list(APPEND CMAKE_MODULE_PATH "${PROJECT_SOURCE_DIR}/cmake")
@@ -28,12 +33,10 @@ if(CMAKE_SYSTEM_NAME STREQUAL "Linux")
   list(APPEND uvwasi_defines _GNU_SOURCE _POSIX_C_SOURCE=200112)
 endif()
 
-option(WITH_SYSTEM_LIBUV "Link to a system libuv library instead of bundling" OFF)
-
-if (WITH_SYSTEM_LIBUV)
-  find_package(LibUV REQUIRED)
+find_package(LIBUV QUIET)
+if(LIBUV_FOUND)
   include_directories(${LIBUV_INCLUDE_DIR})
-else (WITH_SYSTEM_LIBUV)
+else()
   include(FetchContent)
   ## https://libuv.org
   FetchContent_Declare(
@@ -47,8 +50,9 @@ else (WITH_SYSTEM_LIBUV)
       include_directories("${libuv_SOURCE_DIR}/include")
       add_subdirectory(${libuv_SOURCE_DIR} ${libuv_BINARY_DIR} EXCLUDE_FROM_ALL)
   endif()
+  set(LIBUV_INCLUDE_DIR ${libuv_SOURCE_DIR}/include)
   set(LIBUV_LIBRARIES uv_a)
-endif (WITH_SYSTEM_LIBUV)
+endif()
 
 ## uvwasi source code files.
 set(uvwasi_sources
@@ -137,6 +141,49 @@ if(UVWASI_BUILD_TESTS)
     )
 endif()
 
+option(INSTALL_UVWASI "Enable installation of uvwasi. (Projects embedding uvwasi may want to turn this OFF.)" ON)
+if(INSTALL_UVWASI)
+    include(GNUInstallDirs)
+    include(CMakePackageConfigHelpers)
+
+    set(target_export_name ${PROJECT_NAME}Targets CACHE INTERNAL "")
+    set(cmake_files_install_dir ${CMAKE_INSTALL_LIBDIR}/cmake/${PROJECT_NAME})
+
+    set(pkg_config ${PROJECT_BINARY_DIR}/uvwasi.pc)
+    set(version_file ${PROJECT_BINARY_DIR}/${PROJECT_NAME}ConfigVersion.cmake)
+    set(config_file ${PROJECT_BINARY_DIR}/${PROJECT_NAME}Config.cmake)
+
+    configure_file(${PROJECT_SOURCE_DIR}/cmake/uvwasi.pc.in ${pkg_config} @ONLY)
+    write_basic_package_version_file(${version_file} VERSION ${PROJECT_VERSION} COMPATIBILITY AnyNewerVersion)
+    configure_package_config_file(${PROJECT_SOURCE_DIR}/cmake/Config.cmake.in ${config_file} INSTALL_DESTINATION ${cmake_files_install_dir})
+
+    install(
+        TARGETS uvwasi_a uvwasi
+        EXPORT ${target_export_name}
+        RUNTIME DESTINATION ${CMAKE_INSTALL_BINDIR}
+        ARCHIVE DESTINATION ${CMAKE_INSTALL_LIBDIR}
+        LIBRARY DESTINATION ${CMAKE_INSTALL_LIBDIR}
+    )
+    install(
+        DIRECTORY ${PROJECT_SOURCE_DIR}/include/
+        DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}/uvwasi
+        FILES_MATCHING PATTERN "*.h"
+    )
+    install(
+        FILES ${pkg_config}
+        DESTINATION ${CMAKE_INSTALL_LIBDIR}/pkgconfig
+    )
+    install(
+        EXPORT ${target_export_name}
+        NAMESPACE ${PROJECT_NAME}::
+        DESTINATION ${cmake_files_install_dir}
+    )
+    install(
+        FILES ${version_file} ${config_file}
+        DESTINATION ${cmake_files_install_dir}
+    )
+endif()
+
 message(STATUS "summary of uvwasi build options:
 
     Install prefix:  ${CMAKE_INSTALL_PREFIX}
@@ -145,7 +192,8 @@ message(STATUS "summary of uvwasi build options:
       C compiler:    ${CMAKE_C_COMPILER}
       CFLAGS:        ${CMAKE_C_FLAGS_${_build_type}} ${CMAKE_C_FLAGS}
 
-    System libuv:    ${WITH_SYSTEM_LIBUV}
+    LibUV libraries: ${LIBUV_LIBRARIES}
+    LibUV includes:  ${LIBUV_INCLUDE_DIR}
     Debug logging:   ${UVWASI_DEBUG_LOG}
     Code coverage:   ${CODE_COVERAGE}
     ASAN:            ${ASAN}

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -142,7 +142,7 @@ if(UVWASI_BUILD_TESTS)
 endif()
 
 option(INSTALL_UVWASI "Enable installation of uvwasi. (Projects embedding uvwasi may want to turn this OFF.)" ON)
-if(INSTALL_UVWASI)
+if(INSTALL_UVWASI AND NOT CODE_COVERAGE)
     include(GNUInstallDirs)
     include(CMakePackageConfigHelpers)
 

--- a/README.md
+++ b/README.md
@@ -2484,6 +2484,7 @@ To do a release complete the following steps:
   or any of the other releases for example. Use that list in the release commit,
   the GitHub release, and the PR to update uvwasi in Node.js (or any other
   projects where you update it)
+* Update the version in the CMake file. Specifically: https://github.com/nodejs/uvwasi/blob/main/CMakeLists.txt#L5
 * Create a release commit. This should just involve changing one line and
   adding the notable changes. See
   https://github.com/nodejs/uvwasi/commit/6ad5fc996420d0e4e75983ce3deb65f327321f33

--- a/cmake/Config.cmake.in
+++ b/cmake/Config.cmake.in
@@ -1,0 +1,7 @@
+@PACKAGE_INIT@
+include(CMakeFindDependencyMacro)
+
+find_dependency(LibUV)
+
+include("${CMAKE_CURRENT_LIST_DIR}/@target_export_name@.cmake")
+check_required_components("@PROJECT_NAME@")

--- a/cmake/FindLibUV.cmake
+++ b/cmake/FindLibUV.cmake
@@ -4,8 +4,18 @@
 #  LIBUV_LIBRARIES
 #  LIBUV_INCLUDE_DIR, where to find uv.h
 
-FIND_PATH(LIBUV_INCLUDE_DIR NAMES uv.h)
-FIND_LIBRARY(LIBUV_LIBRARIES NAMES uv libuv)
+find_path(LIBUV_INCLUDE_DIR NAMES uv.h)
+find_library(LIBUV_LIBRARIES NAMES uv libuv)
+
+include(FindPackageHandleStandardArgs)
+
+find_package_handle_standard_args(
+  LIBUV
+  FOUND_VAR LIBUV_FOUND
+  REQUIRED_VARS
+    LIBUV_LIBRARIES
+    LIBUV_INCLUDE_DIR
+)
 
 if(WIN32)
   list(APPEND LIBUV_LIBRARIES iphlpapi)

--- a/cmake/uvwasi.pc.in
+++ b/cmake/uvwasi.pc.in
@@ -1,0 +1,14 @@
+prefix=@CMAKE_INSTALL_PREFIX@
+exec_prefix=${prefix}
+libdir=@CMAKE_INSTALL_FULL_LIBDIR@
+includedir=@CMAKE_INSTALL_FULL_INCLUDEDIR@
+bindir=@CMAKE_INSTALL_FULL_BINDIR@
+libuv_includedir=@LIBUV_INCLUDE_DIR@
+
+Name: @PROJECT_NAME@
+Description: @PROJECT_DESCRIPTION@
+Version: @PROJECT_VERSION@
+
+Libs: -L${libdir}
+Libs.private: -l@LIBUV_LIBRARIES@
+Cflags: -I${includedir} -I${libuv_includedir} @uvwasi_cflags@


### PR DESCRIPTION
This reworks the cmake build of the project to add install targets for uvwasi. This will make it possible for pkg-config or cmake build pipelines to discover globally installed uvwasi.

To install uvwasi, you'd run `cmake --install out` after you build.

I also removed the `WITH_SYSTEM_LIBUV` option because we should be using the globally installed libuv if it can be found. If people are very against this change, I can introduce a flag to *disable* this behavior.

I've tested this against a local branch of wasm-micro-runtime and it seems to be working. My plan is to add that build to CI once they accept my changes.

Closes #199