### PR TITLE
fix: small -Wextra-semi warning in uvwasi.c

### DIFF
--- a/src/uvwasi.c
+++ b/src/uvwasi.c
@@ -2564,7 +2564,7 @@ uvwasi_errno_t uvwasi_sock_accept(uvwasi_t* uvwasi,
   /* TODO(mhdawson): Needs implementation */
   UVWASI_DEBUG("uvwasi_sock_accept(uvwasi=%p, unimplemented)\n", uvwasi);
   return UVWASI_ENOTSUP;
-};
+}
 
 
 const char* uvwasi_embedder_err_code_to_string(uvwasi_errno_t code) {


### PR DESCRIPTION
Fix a minor extra semicolon warning.

I found this updating Electron's Node.js roll, since Electron builds Node.js with `-Werror,-Wextra-semi` :smile_cat: 