### PR TITLE
test: fixup windows tests

### DIFF
--- a/test/test-args-get.c
+++ b/test/test-args-get.c
@@ -2,6 +2,7 @@
 #include <stdlib.h>
 #include <string.h>
 #include "uvwasi.h"
+#include "test-common.h"
 
 int main(void) {
   uvwasi_t uvwasi;
@@ -11,6 +12,8 @@ int main(void) {
   uvwasi_size_t argv_buf_size;
   char** args_get_argv;
   char* buf;
+
+  setup_test_environment();
 
   uvwasi_options_init(&init_options);
   init_options.argc = 3;

--- a/test/test-basic-file-io.c
+++ b/test/test-basic-file-io.c
@@ -3,6 +3,7 @@
 #include <string.h>
 #include "uvwasi.h"
 #include "uv.h"
+#include "test-common.h"
 
 #define TEST_TMP_DIR "./out/tmp"
 
@@ -26,6 +27,8 @@ int main(void) {
   uvwasi_size_t nio;
   uvwasi_size_t i;
   int r;
+
+  setup_test_environment();
 
   r = uv_fs_mkdir(NULL, &req, TEST_TMP_DIR, 0777, NULL);
   uv_fs_req_cleanup(&req);

--- a/test/test-clock-time-get.c
+++ b/test/test-clock-time-get.c
@@ -2,6 +2,7 @@
 #include <stdlib.h>
 #include <string.h>
 #include "uvwasi.h"
+#include "test-common.h"
 
 int main(void) {
   uvwasi_t uvwasi;
@@ -9,6 +10,8 @@ int main(void) {
   uvwasi_errno_t err;
   uvwasi_timestamp_t time;
   uvwasi_timestamp_t precision = 1000;
+
+  setup_test_environment();
 
   uvwasi_options_init(&init_options);
 
@@ -22,6 +25,13 @@ int main(void) {
   err = uvwasi_clock_time_get(&uvwasi, UVWASI_CLOCK_MONOTONIC, precision, &time);
   assert(err == 0);
   assert(time > 0);
+
+  // use some cpu time
+  int count = 0;
+  for (int i = 0; i < 100000000; i++) {
+    count++;
+  }
+  assert(count == 100000000);
 
   err = uvwasi_clock_time_get(&uvwasi, UVWASI_CLOCK_PROCESS_CPUTIME_ID, precision, &time);
   assert(err == 0);

--- a/test/test-common.h
+++ b/test/test-common.h
@@ -1,0 +1,10 @@
+#ifdef _WIN32
+#include "crtdbg.h"
+#endif
+
+void static inline setup_test_environment(void) {
+#ifdef _WIN32
+  // disable window popups
+  _CrtSetReportMode(_CRT_ERROR, _CRTDBG_MODE_DEBUG);
+#endif 
+}

--- a/test/test-ebadf-input-validation.c
+++ b/test/test-ebadf-input-validation.c
@@ -1,6 +1,7 @@
 #include <assert.h>
 #include <string.h>
 #include "uvwasi.h"
+#include "test-common.h"
 
 #define CHECK(expr) assert(UVWASI_EBADF == (expr))
 
@@ -19,6 +20,8 @@ int main(void) {
   char* test_str = "foo";
   uvwasi_size_t test_size = 5;
   void* test_void;
+
+  setup_test_environment();
 
   test_void = (void*) &test_fdstat;
 

--- a/test/test-einval-input-validation.c
+++ b/test/test-einval-input-validation.c
@@ -2,6 +2,7 @@
 #include <stdlib.h>
 #include <string.h>
 #include "uvwasi.h"
+#include "test-common.h"
 
 #define CHECK(expr) assert(UVWASI_EINVAL == (expr))
 
@@ -23,6 +24,8 @@ int main(void) {
   uvwasi_subscription_t test_sub;
   uvwasi_event_t test_event;
   uvwasi_fd_t test_fd;
+
+  setup_test_environment();
 
   test_void = (void*) &test_fdstat;
 

--- a/test/test-enotsup-apis.c
+++ b/test/test-enotsup-apis.c
@@ -1,7 +1,10 @@
 #include <assert.h>
 #include "uvwasi.h"
+#include "test-common.h"
 
 int main(void) {
+  setup_test_environment();
+
   /* TODO(cjihrig): This test is intended to be temporary. */
   assert(UVWASI_ENOTSUP == uvwasi_sock_recv(NULL, 0, NULL, 0, 0, NULL, NULL));
   assert(UVWASI_ENOTSUP == uvwasi_sock_send(NULL, 0, NULL, 0, 0, NULL));

--- a/test/test-environ-get.c
+++ b/test/test-environ-get.c
@@ -2,6 +2,7 @@
 #include <stdlib.h>
 #include <string.h>
 #include "uvwasi.h"
+#include "test-common.h"
 
 #ifdef __APPLE__
 # include <crt_externs.h>
@@ -18,6 +19,8 @@ int main(void) {
   uvwasi_size_t env_buf_size;
   char** env_get_env;
   char* buf;
+
+  setup_test_environment();
 
   uvwasi_options_init(&init_options);
   init_options.envp = (const char**) environ;

--- a/test/test-err-to-string.c
+++ b/test/test-err-to-string.c
@@ -1,12 +1,15 @@
 #include <assert.h>
 #include <string.h>
 #include "uvwasi.h"
+#include "test-common.h"
 
 static void check(uvwasi_errno_t err, const char* str) {
   assert(0 == strcmp(uvwasi_embedder_err_code_to_string(err), str));
 }
 
 int main(void) {
+  setup_test_environment();
+
   check(UVWASI_E2BIG, "UVWASI_E2BIG");
   check(UVWASI_EACCES, "UVWASI_EACCES");
   check(UVWASI_EADDRINUSE, "UVWASI_EADDRINUSE");

--- a/test/test-fd-prestat-dir-name.c
+++ b/test/test-fd-prestat-dir-name.c
@@ -3,6 +3,7 @@
 #include <string.h>
 #include "uvwasi.h"
 #include "uv.h"
+#include "test-common.h"
 
 #define TEST_TMP_DIR "./out/tmp"
 
@@ -15,6 +16,8 @@ int main(void) {
   char* prestat_buf;
   uv_fs_t req;
   int r;
+
+  setup_test_environment();
 
   r = uv_fs_mkdir(NULL, &req, TEST_TMP_DIR, 0777, NULL);
   uv_fs_req_cleanup(&req);

--- a/test/test-fd-readdir-ls.c
+++ b/test/test-fd-readdir-ls.c
@@ -4,6 +4,7 @@
 #include "uv.h"
 #include "uvwasi.h"
 #include "wasi_serdes.h"
+#include "test-common.h"
 
 #define TEST_TMP_DIR "./out/tmp"
 #define TEST_PATH_READDIR TEST_TMP_DIR "/test_readdir_ls"
@@ -44,6 +45,8 @@ int main(void) {
   uvwasi_fd_t tmp_fd = 3;
   char buf[4096];
   int r;
+
+  setup_test_environment();
 
   r = uv_fs_mkdir(NULL, &req, TEST_TMP_DIR, 0777, NULL);
   uv_fs_req_cleanup(&req);

--- a/test/test-fd-readdir.c
+++ b/test/test-fd-readdir.c
@@ -4,6 +4,7 @@
 #include "uv.h"
 #include "uvwasi.h"
 #include "wasi_serdes.h"
+#include "test-common.h"
 
 #define TEST_TMP_DIR "./out/tmp"
 #define TEST_PATH_READDIR TEST_TMP_DIR "/test_readdir"
@@ -44,6 +45,8 @@ int main(void) {
   char buf[1024];
   char* name;
   int r;
+
+  setup_test_environment();
 
   r = uv_fs_mkdir(NULL, &req, TEST_TMP_DIR, 0777, NULL);
   uv_fs_req_cleanup(&req);

--- a/test/test-filestat-set-times.c
+++ b/test/test-filestat-set-times.c
@@ -3,6 +3,7 @@
 #include <string.h>
 #include "uvwasi.h"
 #include "uv.h"
+#include "test-common.h"
 
 #define TEST_TMP_DIR "./out/tmp"
 
@@ -31,6 +32,8 @@ int main(void) {
   size_t linksize;
   uv_fs_t req;
   int r;
+
+  setup_test_environment();
 
   r = uv_fs_mkdir(NULL, &req, TEST_TMP_DIR, 0777, NULL);
   uv_fs_req_cleanup(&req);

--- a/test/test-multiple-wasi-destroys.c
+++ b/test/test-multiple-wasi-destroys.c
@@ -2,10 +2,13 @@
 #include <stdlib.h>
 #include <string.h>
 #include "uvwasi.h"
+#include "test-common.h"
 
 int main(void) {
   uvwasi_t uvwasi;
   uvwasi_options_t init_options;
+
+  setup_test_environment();
 
   uvwasi_options_init(&init_options);
   assert(init_options.in == 0);

--- a/test/test-path-create-remove-directory.c
+++ b/test/test-path-create-remove-directory.c
@@ -3,6 +3,7 @@
 #include <string.h>
 #include "uvwasi.h"
 #include "uv.h"
+#include "test-common.h"
 
 #define TEST_TMP_DIR "./out/tmp"
 #define TEST_MKDIR_PATH TEST_TMP_DIR "/test_dir"
@@ -13,6 +14,8 @@ int main(void) {
   uvwasi_errno_t err;
   uv_fs_t req;
   int r;
+
+  setup_test_environment();
 
   r = uv_fs_mkdir(NULL, &req, TEST_TMP_DIR, 0777, NULL);
   uv_fs_req_cleanup(&req);

--- a/test/test-path-resolution.c
+++ b/test/test-path-resolution.c
@@ -5,6 +5,7 @@
 #include "../src/fd_table.h"
 #include "../src/path_resolver.h"
 #include "../src/wasi_rights.h"
+#include "test-common.h"
 
 #define BUFFER_SIZE 1024
 
@@ -28,6 +29,8 @@ static uvwasi_errno_t check(char* fd_mp, char* fd_rp, char* path, char** res) {
   struct uvwasi_fd_wrap_t fd;
   uvwasi_errno_t err;
   uvwasi_size_t len;
+
+  setup_test_environment();
 
   len = strlen(path);
   fd.id = 3;

--- a/test/test-poll-state-cleanup.c
+++ b/test/test-poll-state-cleanup.c
@@ -1,5 +1,6 @@
 #include <assert.h>
 #include "uvwasi.h"
+#include "test-common.h"
 
 int main(void) {
   uvwasi_t uvwasi;
@@ -8,6 +9,8 @@ int main(void) {
   uvwasi_event_t event;
   uvwasi_size_t nevents;
   uvwasi_errno_t err;
+
+  setup_test_environment();
 
   uvwasi_options_init(&init_options);
   err = uvwasi_init(&uvwasi, &init_options);

--- a/test/test-proc-exit.c
+++ b/test/test-proc-exit.c
@@ -1,6 +1,9 @@
 #include "uvwasi.h"
+#include "test-common.h"
 
 int main(void) {
+  setup_test_environment();
+
   /* uvwasi_proc_exit() is the only call that works with a NULL uvwasi_t. */
   uvwasi_proc_exit(NULL, 0);
   return 1;

--- a/test/test-random-get.c
+++ b/test/test-random-get.c
@@ -2,6 +2,7 @@
 #include <stdlib.h>
 #include <string.h>
 #include "uvwasi.h"
+#include "test-common.h"
 
 #define BUFFER_SIZE 1024
 
@@ -12,6 +13,8 @@ int main(void) {
   unsigned char* buf;
   int success;
   int i;
+
+  setup_test_environment();
 
   uvwasi_options_init(&init_options);
   err = uvwasi_init(&uvwasi, &init_options);

--- a/test/test-serdes.c
+++ b/test/test-serdes.c
@@ -2,6 +2,7 @@
 #include <stdlib.h>
 #include <string.h>
 #include "wasi_serdes.h"
+#include "test-common.h"
 
 void test_bound_checks(void);
 void test_basic_types(void);
@@ -12,6 +13,8 @@ void test_event_t(void);
 void test_subscription_t(void);
 
 int main(void) {
+  setup_test_environment();
+
   test_bound_checks();
   test_basic_types();
   test_fdstat_t();

--- a/test/test-uv-mapping.c
+++ b/test/test-uv-mapping.c
@@ -1,6 +1,7 @@
 #include <assert.h>
 #include <stdlib.h>
 #include "../src/uv_mapping.h"
+#include "test-common.h"
 
 #define CHECK_ERR(err) assert(uvwasi__translate_uv_error(UV_ ## err ) ==      \
                               UVWASI_ ## err)
@@ -10,6 +11,8 @@
 #endif /* _WIN32 */
 
 int main(void) {
+  setup_test_environment();
+
   /* Verify error code translation. */
   CHECK_ERR(E2BIG);
   CHECK_ERR(EACCES);

--- a/test/test-wasi-destroy-without-init.c
+++ b/test/test-wasi-destroy-without-init.c
@@ -2,8 +2,11 @@
 #include <stdlib.h>
 #include <string.h>
 #include "uvwasi.h"
+#include "test-common.h"
 
 int main(void) {
+  setup_test_environment();
+
   uvwasi_t uvwasi = {0};
   uvwasi_destroy(&uvwasi);
   return 0;


### PR DESCRIPTION
- fix intermittent failure in test-clock-time-get.
- avoid window popups that cause any failed test to just hang until test times out