### PR TITLE
Forbid fd_advise on directories

### DIFF
--- a/src/uvwasi.c
+++ b/src/uvwasi.c
@@ -17,6 +17,10 @@
 # define UVWASI_FD_READDIR_SUPPORTED 1
 #endif
 
+#if !defined(S_ISDIR) && defined(S_IFMT) && defined(S_IFDIR)
+  #define S_ISDIR(m) (((m) & S_IFMT) == S_IFDIR)
+#endif
+
 #include "uvwasi.h"
 #include "uvwasi_alloc.h"
 #include "uv.h"

--- a/src/uvwasi.c
+++ b/src/uvwasi.c
@@ -8,6 +8,8 @@
 # include <dirent.h>
 # include <time.h>
 #else
+# define _CRT_INTERNAL_NONSTDC_NAMES 1
+# include <sys/stat.h>
 # include <io.h>
 #endif /* _WIN32 */
 

--- a/src/uvwasi.c
+++ b/src/uvwasi.c
@@ -625,9 +625,9 @@ uvwasi_errno_t uvwasi_fd_advise(uvwasi_t* uvwasi,
   struct uvwasi_fd_wrap_t* wrap;
   uvwasi_errno_t err;
   uv_fs_t req;
+  int r;
 #ifdef POSIX_FADV_NORMAL
   int mapped_advice;
-  int r;
 #endif /* POSIX_FADV_NORMAL */
 
   UVWASI_DEBUG("uvwasi_fd_advise(uvwasi=%p, fd=%d, offset=%"PRIu64", "

--- a/test/test-fd-advise-dir.c
+++ b/test/test-fd-advise-dir.c
@@ -1,0 +1,45 @@
+#include <assert.h>
+#include <stdlib.h>
+
+#include "uv.h"
+#include "uvwasi.h"
+#include "test-common.h"
+
+#define TEST_TMP_DIR "./out/tmp"
+#define TEST_PATH_ADVISE TEST_TMP_DIR "/test_fd_advise_dir"
+
+int main(void) {
+#if !defined(_WIN32) && !defined(__ANDROID__)
+  uvwasi_t uvwasi;
+  uvwasi_options_t init_options;
+  uv_fs_t req;
+  uvwasi_errno_t err;
+  int r;
+
+  setup_test_environment();
+
+  r = uv_fs_mkdir(NULL, &req, TEST_TMP_DIR, 0777, NULL);
+  uv_fs_req_cleanup(&req);
+  assert(r == 0 || r == UV_EEXIST);
+
+  r = uv_fs_mkdir(NULL, &req, TEST_PATH_ADVISE, 0777, NULL);
+  uv_fs_req_cleanup(&req);
+  assert(r == 0 || r == UV_EEXIST);
+
+  uvwasi_options_init(&init_options);
+  init_options.preopenc = 1;
+  init_options.preopens = calloc(1, sizeof(uvwasi_preopen_t));
+  init_options.preopens[0].mapped_path = "/var";
+  init_options.preopens[0].real_path = TEST_PATH_ADVISE;
+
+  err = uvwasi_init(&uvwasi, &init_options);
+  assert(err == 0);
+
+  err = uvwasi_fd_advise(&uvwasi, 3, 10, 20, UVWASI_ADVICE_DONTNEED);
+  assert(err == UVWASI_EBADF);
+
+  uvwasi_destroy(&uvwasi);
+  free(init_options.preopens);
+#endif /* !defined(_WIN32) && !defined(__ANDROID__) */
+  return 0;
+}


### PR DESCRIPTION
This commit adds a check to `fd_advise`.  If the fd is a directory, return `ebadf`.  This brings uvwasi in line with Wasmtime's behavior. WASI folks have [stated](https://github.com/bytecodealliance/wasmtime/issues/6505#issuecomment-1574122949) that fd_advise should not work on directories as this is a Linux-specific behavior.