### PR TITLE
Error on ambiguous fstflags

### DIFF
--- a/src/uvwasi.c
+++ b/src/uvwasi.c
@@ -37,10 +37,11 @@
 
 #define VALIDATE_FSTFLAGS_OR_RETURN(flags)                                    \
   do {                                                                        \
-    if ((flags) & ~(UVWASI_FILESTAT_SET_ATIM |                                \
-                    UVWASI_FILESTAT_SET_ATIM_NOW |                            \
-                    UVWASI_FILESTAT_SET_MTIM |                                \
-                    UVWASI_FILESTAT_SET_MTIM_NOW)) {                          \
+    uvwasi_fstflags_t f = flags;                                              \
+    if (((f) & ~(UVWASI_FILESTAT_SET_ATIM | UVWASI_FILESTAT_SET_ATIM_NOW |    \
+                 UVWASI_FILESTAT_SET_MTIM | UVWASI_FILESTAT_SET_MTIM_NOW)) || \
+        ((f) & (UVWASI_FILESTAT_SET_ATIM | UVWASI_FILESTAT_SET_ATIM_NOW)) ||  \
+        ((f) & (UVWASI_FILESTAT_SET_MTIM | UVWASI_FILESTAT_SET_MTIM_NOW))) {  \
       return UVWASI_EINVAL;                                                   \
     }                                                                         \
   } while (0)

--- a/src/uvwasi.c
+++ b/src/uvwasi.c
@@ -40,8 +40,10 @@
     uvwasi_fstflags_t f = flags;                                              \
     if (((f) & ~(UVWASI_FILESTAT_SET_ATIM | UVWASI_FILESTAT_SET_ATIM_NOW |    \
                  UVWASI_FILESTAT_SET_MTIM | UVWASI_FILESTAT_SET_MTIM_NOW)) || \
-        ((f) & (UVWASI_FILESTAT_SET_ATIM | UVWASI_FILESTAT_SET_ATIM_NOW)) ||  \
-        ((f) & (UVWASI_FILESTAT_SET_MTIM | UVWASI_FILESTAT_SET_MTIM_NOW))) {  \
+        ((f) & (UVWASI_FILESTAT_SET_ATIM | UVWASI_FILESTAT_SET_ATIM_NOW))     \
+            == (UVWASI_FILESTAT_SET_ATIM | UVWASI_FILESTAT_SET_ATIM_NOW) ||   \
+        ((f) & (UVWASI_FILESTAT_SET_MTIM | UVWASI_FILESTAT_SET_MTIM_NOW))     \
+            == (UVWASI_FILESTAT_SET_MTIM | UVWASI_FILESTAT_SET_MTIM_NOW)) {   \
       return UVWASI_EINVAL;                                                   \
     }                                                                         \
   } while (0)
@@ -1776,8 +1778,6 @@ uvwasi_errno_t uvwasi_path_filestat_set_times(uvwasi_t* uvwasi,
   if (uvwasi == NULL || path == NULL)
     return UVWASI_EINVAL;
 
-  VALIDATE_FSTFLAGS_OR_RETURN(fst_flags);
-
   err = uvwasi_fd_table_get(uvwasi->fds,
                             fd,
                             &wrap,
@@ -1785,6 +1785,8 @@ uvwasi_errno_t uvwasi_path_filestat_set_times(uvwasi_t* uvwasi,
                             0);
   if (err != UVWASI_ESUCCESS)
     return err;
+
+  VALIDATE_FSTFLAGS_OR_RETURN(fst_flags);
 
   err = uvwasi__resolve_path(uvwasi,
                              wrap,

--- a/test/test-fstflags-validate.c
+++ b/test/test-fstflags-validate.c
@@ -1,0 +1,47 @@
+#include "test-common.h"
+#include "uv.h"
+#include "uvwasi.h"
+#include <assert.h>
+#include <stdlib.h>
+#include <string.h>
+
+#define TEST_TMP_DIR "./out/tmp"
+
+int main(void) {
+#if !defined(_WIN32) && !defined(__ANDROID__)
+  uvwasi_t uvwasi;
+  uvwasi_options_t init_options;
+  uvwasi_errno_t err;
+  uv_fs_t req;
+  int r;
+
+  setup_test_environment();
+
+  r = uv_fs_mkdir(NULL, &req, TEST_TMP_DIR, 0777, NULL);
+  uv_fs_req_cleanup(&req);
+  assert(r == 0 || r == UV_EEXIST);
+
+  uvwasi_options_init(&init_options);
+  init_options.preopenc = 1;
+  init_options.preopens = calloc(1, sizeof(uvwasi_preopen_t));
+  init_options.preopens[0].mapped_path = "/var";
+  init_options.preopens[0].real_path = TEST_TMP_DIR;
+
+  err = uvwasi_init(&uvwasi, &init_options);
+  assert(err == 0);
+
+  err = uvwasi_fd_filestat_set_times(&uvwasi, 3, 100, 200,
+                                     UVWASI_FILESTAT_SET_ATIM |
+                                         UVWASI_FILESTAT_SET_ATIM_NOW);
+  assert(err == UVWASI_EINVAL);
+
+  err = uvwasi_fd_filestat_set_times(&uvwasi, 3, 100, 200,
+                                     UVWASI_FILESTAT_SET_MTIM |
+                                         UVWASI_FILESTAT_SET_MTIM_NOW);
+  assert(err == UVWASI_EINVAL);
+
+  uvwasi_destroy(&uvwasi);
+  free(init_options.preopens);
+#endif /* !defined(_WIN32) && !defined(__ANDROID__) */
+  return 0;
+}


### PR DESCRIPTION
This commit adds a check to the validator macro for `fstflags` to return `inval` if the caller requests both `atim` and `atim_now` or both `mtim` and `mtim_now` because the request is ambiguous.  This behavior is consistent across other runtimes (WasmEdge, Wasmtime, WAMR).