### PR TITLE
chore: fix -Wshadow error in uvwasi.c

### DIFF
--- a/src/uvwasi.c
+++ b/src/uvwasi.c
@@ -2806,7 +2806,7 @@ uvwasi_errno_t uvwasi_sock_accept(uvwasi_t* uvwasi,
         goto close_sock_and_error_exit;
       }
 
-      int r = uv_accept((uv_stream_t*) wrap->sock, (uv_stream_t*) uv_connect_sock);
+      r = uv_accept((uv_stream_t*) wrap->sock, (uv_stream_t*) uv_connect_sock);
       if (r == UV_EAGAIN) {
 	// still no connection or error so run the loop again
         continue;


### PR DESCRIPTION
Refs https://github.com/electron/electron/pull/40675/files#diff-8df91bd501edd943197bf16d478ebd9b4be08f7b0ea13de788da961d4315febe

Fixes a `-Wshadow` compilation error hit by Electron when upgrading to Node.js v20.10.0 