### PR TITLE
No-op instead of error on empty read/write

### DIFF
--- a/src/uvwasi.c
+++ b/src/uvwasi.c
@@ -1175,6 +1175,15 @@ uvwasi_errno_t uvwasi_fd_pread(uvwasi_t* uvwasi,
     return err;
   }
 
+  // libuv returns EINVAL in this case.  To behave consistently with other
+  // Wasm runtimes, return OK here with a no-op.
+  if (iovs_len == 0) {
+    uv_mutex_unlock(&wrap->mutex);
+    uvwasi__free(uvwasi, bufs);
+    *nread = 0;
+    return UVWASI_ESUCCESS;
+  }
+
   r = uv_fs_read(NULL, &req, wrap->fd, bufs, iovs_len, offset, NULL);
   uv_mutex_unlock(&wrap->mutex);
   uvread = req.result;
@@ -1299,6 +1308,15 @@ uvwasi_errno_t uvwasi_fd_pwrite(uvwasi_t* uvwasi,
     return err;
   }
 
+  // libuv returns EINVAL in this case.  To behave consistently with other
+  // Wasm runtimes, return OK here with a no-op.
+  if (iovs_len == 0) {
+    uv_mutex_unlock(&wrap->mutex);
+    uvwasi__free(uvwasi, bufs);
+    *nwritten = 0;
+    return UVWASI_ESUCCESS;
+  }
+
   r = uv_fs_write(NULL, &req, wrap->fd, bufs, iovs_len, offset, NULL);
   uv_mutex_unlock(&wrap->mutex);
   uvwritten = req.result;
@@ -1332,7 +1350,6 @@ uvwasi_errno_t uvwasi_fd_read(uvwasi_t* uvwasi,
                iovs,
                iovs_len,
                nread);
-
   if (uvwasi == NULL || iovs == NULL || nread == NULL)
     return UVWASI_EINVAL;
 
@@ -1344,6 +1361,15 @@ uvwasi_errno_t uvwasi_fd_read(uvwasi_t* uvwasi,
   if (err != UVWASI_ESUCCESS) {
     uv_mutex_unlock(&wrap->mutex);
     return err;
+  }
+
+  // libuv returns EINVAL in this case.  To behave consistently with other
+  // Wasm runtimes, return OK here with a no-op.
+  if (iovs_len == 0) {
+    uv_mutex_unlock(&wrap->mutex);
+    uvwasi__free(uvwasi, bufs);
+    *nread = 0;
+    return UVWASI_ESUCCESS;
   }
 
   r = uv_fs_read(NULL, &req, wrap->fd, bufs, iovs_len, -1, NULL);
@@ -1645,6 +1671,15 @@ uvwasi_errno_t uvwasi_fd_write(uvwasi_t* uvwasi,
   if (err != UVWASI_ESUCCESS) {
     uv_mutex_unlock(&wrap->mutex);
     return err;
+  }
+
+  // libuv returns EINVAL in this case.  To behave consistently with other
+  // Wasm runtimes, return OK here with a no-op.
+  if (iovs_len == 0) {
+    uv_mutex_unlock(&wrap->mutex);
+    uvwasi__free(uvwasi, bufs);
+    *nwritten = 0;
+    return UVWASI_ESUCCESS;
   }
 
   r = uv_fs_write(NULL, &req, wrap->fd, bufs, iovs_len, -1, NULL);

--- a/src/uvwasi.c
+++ b/src/uvwasi.c
@@ -1291,7 +1291,7 @@ uvwasi_errno_t uvwasi_fd_pwrite(uvwasi_t* uvwasi,
                offset,
                nwritten);
 
-  if (uvwasi == NULL || (iovs == NULL && iovs > 0) || nwritten == NULL || offset > INT64_MAX)
+  if (uvwasi == NULL || (iovs == NULL && iovs_len > 0) || nwritten == NULL || offset > INT64_MAX)
     return UVWASI_EINVAL;
 
   err = uvwasi_fd_table_get(uvwasi->fds,

--- a/src/uvwasi.c
+++ b/src/uvwasi.c
@@ -1169,19 +1169,18 @@ uvwasi_errno_t uvwasi_fd_pread(uvwasi_t* uvwasi,
   if (err != UVWASI_ESUCCESS)
     return err;
 
-  err = uvwasi__setup_iovs(uvwasi, &bufs, iovs, iovs_len);
-  if (err != UVWASI_ESUCCESS) {
-    uv_mutex_unlock(&wrap->mutex);
-    return err;
-  }
-
   // libuv returns EINVAL in this case.  To behave consistently with other
   // Wasm runtimes, return OK here with a no-op.
   if (iovs_len == 0) {
     uv_mutex_unlock(&wrap->mutex);
-    uvwasi__free(uvwasi, bufs);
     *nread = 0;
     return UVWASI_ESUCCESS;
+  }
+
+  err = uvwasi__setup_iovs(uvwasi, &bufs, iovs, iovs_len);
+  if (err != UVWASI_ESUCCESS) {
+    uv_mutex_unlock(&wrap->mutex);
+    return err;
   }
 
   r = uv_fs_read(NULL, &req, wrap->fd, bufs, iovs_len, offset, NULL);
@@ -1302,19 +1301,18 @@ uvwasi_errno_t uvwasi_fd_pwrite(uvwasi_t* uvwasi,
   if (err != UVWASI_ESUCCESS)
     return err;
 
-  err = uvwasi__setup_ciovs(uvwasi, &bufs, iovs, iovs_len);
-  if (err != UVWASI_ESUCCESS) {
-    uv_mutex_unlock(&wrap->mutex);
-    return err;
-  }
-
   // libuv returns EINVAL in this case.  To behave consistently with other
   // Wasm runtimes, return OK here with a no-op.
   if (iovs_len == 0) {
     uv_mutex_unlock(&wrap->mutex);
-    uvwasi__free(uvwasi, bufs);
     *nwritten = 0;
     return UVWASI_ESUCCESS;
+  }
+
+  err = uvwasi__setup_ciovs(uvwasi, &bufs, iovs, iovs_len);
+  if (err != UVWASI_ESUCCESS) {
+    uv_mutex_unlock(&wrap->mutex);
+    return err;
   }
 
   r = uv_fs_write(NULL, &req, wrap->fd, bufs, iovs_len, offset, NULL);
@@ -1357,19 +1355,18 @@ uvwasi_errno_t uvwasi_fd_read(uvwasi_t* uvwasi,
   if (err != UVWASI_ESUCCESS)
     return err;
 
-  err = uvwasi__setup_iovs(uvwasi, &bufs, iovs, iovs_len);
-  if (err != UVWASI_ESUCCESS) {
-    uv_mutex_unlock(&wrap->mutex);
-    return err;
-  }
-
   // libuv returns EINVAL in this case.  To behave consistently with other
   // Wasm runtimes, return OK here with a no-op.
   if (iovs_len == 0) {
     uv_mutex_unlock(&wrap->mutex);
-    uvwasi__free(uvwasi, bufs);
     *nread = 0;
     return UVWASI_ESUCCESS;
+  }
+
+  err = uvwasi__setup_iovs(uvwasi, &bufs, iovs, iovs_len);
+  if (err != UVWASI_ESUCCESS) {
+    uv_mutex_unlock(&wrap->mutex);
+    return err;
   }
 
   r = uv_fs_read(NULL, &req, wrap->fd, bufs, iovs_len, -1, NULL);
@@ -1667,19 +1664,18 @@ uvwasi_errno_t uvwasi_fd_write(uvwasi_t* uvwasi,
   if (err != UVWASI_ESUCCESS)
     return err;
 
-  err = uvwasi__setup_ciovs(uvwasi, &bufs, iovs, iovs_len);
-  if (err != UVWASI_ESUCCESS) {
-    uv_mutex_unlock(&wrap->mutex);
-    return err;
-  }
-
   // libuv returns EINVAL in this case.  To behave consistently with other
   // Wasm runtimes, return OK here with a no-op.
   if (iovs_len == 0) {
     uv_mutex_unlock(&wrap->mutex);
-    uvwasi__free(uvwasi, bufs);
     *nwritten = 0;
     return UVWASI_ESUCCESS;
+  }
+
+  err = uvwasi__setup_ciovs(uvwasi, &bufs, iovs, iovs_len);
+  if (err != UVWASI_ESUCCESS) {
+    uv_mutex_unlock(&wrap->mutex);
+    return err;
   }
 
   r = uv_fs_write(NULL, &req, wrap->fd, bufs, iovs_len, -1, NULL);

--- a/src/uvwasi.c
+++ b/src/uvwasi.c
@@ -1158,7 +1158,7 @@ uvwasi_errno_t uvwasi_fd_pread(uvwasi_t* uvwasi,
                offset,
                nread);
 
-  if (uvwasi == NULL || iovs == NULL || nread == NULL)
+  if (uvwasi == NULL || (iovs == NULL && iovs_len > 0) || nread == NULL || offset > INT64_MAX)
     return UVWASI_EINVAL;
 
   err = uvwasi_fd_table_get(uvwasi->fds,
@@ -1291,7 +1291,7 @@ uvwasi_errno_t uvwasi_fd_pwrite(uvwasi_t* uvwasi,
                offset,
                nwritten);
 
-  if (uvwasi == NULL || iovs == NULL || nwritten == NULL || offset > INT64_MAX)
+  if (uvwasi == NULL || (iovs == NULL && iovs > 0) || nwritten == NULL || offset > INT64_MAX)
     return UVWASI_EINVAL;
 
   err = uvwasi_fd_table_get(uvwasi->fds,
@@ -1350,7 +1350,7 @@ uvwasi_errno_t uvwasi_fd_read(uvwasi_t* uvwasi,
                iovs,
                iovs_len,
                nread);
-  if (uvwasi == NULL || iovs == NULL || nread == NULL)
+  if (uvwasi == NULL || (iovs == NULL && iovs_len > 0) || nread == NULL)
     return UVWASI_EINVAL;
 
   err = uvwasi_fd_table_get(uvwasi->fds, fd, &wrap, UVWASI_RIGHT_FD_READ, 0);
@@ -1660,7 +1660,7 @@ uvwasi_errno_t uvwasi_fd_write(uvwasi_t* uvwasi,
                iovs_len,
                nwritten);
 
-  if (uvwasi == NULL || iovs == NULL || nwritten == NULL)
+  if (uvwasi == NULL || (iovs == NULL && iovs_len > 0) || nwritten == NULL)
     return UVWASI_EINVAL;
 
   err = uvwasi_fd_table_get(uvwasi->fds, fd, &wrap, UVWASI_RIGHT_FD_WRITE, 0);

--- a/test/test-fd-read-empty.c
+++ b/test/test-fd-read-empty.c
@@ -1,0 +1,82 @@
+#include <assert.h>
+#include <stdint.h>
+#include <stdlib.h>
+#include <string.h>
+#include "uvwasi.h"
+#include "uv.h"
+#include "test-common.h"
+
+#define TEST_TMP_DIR "./out/tmp"
+
+int main(void) {
+  const char* path = "file.txt";
+  uvwasi_t uvwasi;
+  uvwasi_iovec_t* iovs;
+  uvwasi_fd_t fd;
+  uvwasi_options_t init_options;
+  uvwasi_rights_t fs_rights_base;
+  uvwasi_size_t nwritten;
+  uvwasi_size_t iovs_len = 0;
+  uvwasi_errno_t err;
+  uv_fs_t req;
+  int r;
+
+  setup_test_environment();
+
+  r = uv_fs_mkdir(NULL, &req, TEST_TMP_DIR, 0777, NULL);
+  uv_fs_req_cleanup(&req);
+  assert(r == 0 || r == UV_EEXIST);
+
+  uvwasi_options_init(&init_options);
+  init_options.preopenc = 1;
+  init_options.preopens = calloc(1, sizeof(uvwasi_preopen_t));
+  init_options.preopens[0].mapped_path = "/var";
+  init_options.preopens[0].real_path = TEST_TMP_DIR;
+
+  err = uvwasi_init(&uvwasi, &init_options);
+  assert(err == 0);
+
+  // Create a file.
+  fs_rights_base = UVWASI_RIGHT_FD_DATASYNC |
+                   UVWASI_RIGHT_FD_FILESTAT_GET |
+                   UVWASI_RIGHT_FD_FILESTAT_SET_SIZE |
+                   UVWASI_RIGHT_FD_READ |
+                   UVWASI_RIGHT_FD_SEEK |
+                   UVWASI_RIGHT_FD_SYNC |
+                   UVWASI_RIGHT_FD_TELL |
+                   UVWASI_RIGHT_FD_WRITE |
+                   UVWASI_RIGHT_PATH_UNLINK_FILE;
+  err = uvwasi_path_open(&uvwasi,
+                         3,
+                         1,
+                         path,
+                         strlen(path) + 1,
+                         UVWASI_O_CREAT,
+                         fs_rights_base,
+                         0,
+                         0,
+                         &fd);
+  assert(err == 0);
+
+  iovs = calloc(iovs_len, sizeof(uvwasi_ciovec_t));
+  assert(iovs != NULL);
+
+  for (int i = 0; i < iovs_len; i++) {
+    iovs[i].buf_len = 0;
+    iovs[i].buf = malloc(0);
+  }
+
+  err = uvwasi_fd_read(&uvwasi, fd, iovs, iovs_len, &nwritten);
+  assert(err == UVWASI_ESUCCESS);
+
+  uvwasi_destroy(&uvwasi);
+
+  for (int i = 0; i < iovs_len; i++) {
+    free((void *) iovs[i].buf);
+  }
+
+  free(iovs);
+  free(init_options.preopens);
+
+  return 0;
+}


### PR DESCRIPTION
This commit inserts a special case to `fd_{read,write,pread,pwrite}` such that passing in an empty list of buffers results in a no-op.  This behavior is consistent with Linux host as well as other Wasm runtimes.

fixes #260