### PR TITLE
Disallow malformed path with null byte

### DIFF
--- a/src/path_resolver.c
+++ b/src/path_resolver.c
@@ -429,6 +429,11 @@ start:
   normalized_path = NULL;
   err = UVWASI_ESUCCESS;
 
+  if (input_len != strnlen(input, input_len - 1) + 1) {
+    err = UVWASI_EINVAL;
+    goto exit;
+  }
+
   if (1 == uvwasi__is_absolute_path(input, input_len)) {
     err = uvwasi__normalize_absolute_path(uvwasi,
                                           fd,

--- a/test/test-basic-file-io.c
+++ b/test/test-basic-file-io.c
@@ -180,7 +180,7 @@ int main(void) {
                                  3,
                                  UVWASI_LOOKUP_SYMLINK_FOLLOW,
                                  linkname,
-                                 strlen(path) + 1,
+                                 strlen(linkname) + 1,
                                  &stats2);
   assert(err == 0);
   assert(stats2.st_dev == stats.st_dev);
@@ -197,7 +197,7 @@ int main(void) {
                                  3,
                                  0,
                                  linkname,
-                                 strlen(path) + 1,
+                                 strlen(linkname) + 1,
                                  &stats2);
   assert(err == 0);
   assert(stats2.st_dev == stats.st_dev);

--- a/test/test-path-open-malformed-path.c
+++ b/test/test-path-open-malformed-path.c
@@ -1,0 +1,53 @@
+#include <assert.h>
+#include <stdint.h>
+#include <stdlib.h>
+#include <string.h>
+#include "uvwasi.h"
+#include "uv.h"
+#include "test-common.h"
+
+#define TEST_TMP_DIR "./out/tmp"
+
+int main(void) {
+  const char* path = "file.txt\0";
+  uvwasi_t uvwasi;
+  uvwasi_fd_t fd;
+  uvwasi_options_t init_options;
+  uvwasi_errno_t err;
+  uv_fs_t req;
+  int r;
+
+  setup_test_environment();
+
+  r = uv_fs_mkdir(NULL, &req, TEST_TMP_DIR, 0777, NULL);
+  uv_fs_req_cleanup(&req);
+  assert(r == 0 || r == UV_EEXIST);
+
+  uvwasi_options_init(&init_options);
+  init_options.preopenc = 1;
+  init_options.preopens = calloc(1, sizeof(uvwasi_preopen_t));
+  init_options.preopens[0].mapped_path = "/var";
+  init_options.preopens[0].real_path = TEST_TMP_DIR;
+
+  err = uvwasi_init(&uvwasi, &init_options);
+  assert(err == 0);
+
+  // Create a file.
+  err = uvwasi_path_open(&uvwasi,
+                         3,
+                         1,
+                         path,
+                         10,
+                         UVWASI_O_CREAT,
+                         0,
+                         0,
+                         0,
+                         &fd);
+  assert(err == UVWASI_EINVAL);
+
+  uvwasi_destroy(&uvwasi);
+  free(init_options.preopens);
+
+  return 0;
+}
+


### PR DESCRIPTION
This commit adds a check when resolving path such that any null bytes in the input path causes errno `inval`.  This is consistent with other runtimes like Wasmtime, Wasmer, Wazero, WasmEdge, and WAMR.

fixes #265