### PR TITLE
Preserve trailing slash in file path where it makes sense

### DIFF
--- a/src/uvwasi.c
+++ b/src/uvwasi.c
@@ -2105,8 +2105,13 @@ uvwasi_errno_t uvwasi_path_open(uvwasi_t* uvwasi,
   if (err != UVWASI_ESUCCESS)
     goto close_file_and_error_exit;
 
-  if ((o_flags & UVWASI_O_DIRECTORY) != 0 &&
-      filetype != UVWASI_FILETYPE_DIRECTORY) {
+  if (
+    (filetype != UVWASI_FILETYPE_DIRECTORY)
+    && (
+      (o_flags & UVWASI_O_DIRECTORY) != 0
+      || (resolved_path[strlen(resolved_path) - 1] == '/')
+    )
+  ) {
     err = UVWASI_ENOTDIR;
     goto close_file_and_error_exit;
   }

--- a/test/test-path-open-trailing-slash.c
+++ b/test/test-path-open-trailing-slash.c
@@ -1,0 +1,56 @@
+#include <assert.h>
+#include <stdint.h>
+#include <stdlib.h>
+#include <string.h>
+#include "uvwasi.h"
+#include "uv.h"
+#include "test-common.h"
+
+#define TEST_TMP_DIR "./out/tmp"
+#define TEST_FILE    "./out/tmp/test-path-open-trailing-slash.file"
+
+int main(void) {
+  const char* path = "test-path-open-trailing-slash.file/";
+  uvwasi_t uvwasi;
+  uvwasi_fd_t fd;
+  uvwasi_options_t init_options;
+  uvwasi_errno_t err;
+  uv_fs_t req;
+  int r;
+
+  setup_test_environment();
+
+  r = uv_fs_mkdir(NULL, &req, TEST_TMP_DIR, 0777, NULL);
+  uv_fs_req_cleanup(&req);
+  assert(r == 0 || r == UV_EEXIST);
+
+  r = uv_fs_open(NULL, &req, TEST_FILE, UV_FS_O_CREAT | UV_FS_O_RDWR, 0777, NULL);
+  uv_fs_req_cleanup(&req);
+  assert(r >= 0);
+
+  uvwasi_options_init(&init_options);
+  init_options.preopenc = 1;
+  init_options.preopens = calloc(1, sizeof(uvwasi_preopen_t));
+  init_options.preopens[0].mapped_path = "/var";
+  init_options.preopens[0].real_path = TEST_TMP_DIR;
+
+  err = uvwasi_init(&uvwasi, &init_options);
+  assert(err == 0);
+
+  err = uvwasi_path_open(&uvwasi,
+                         3,
+                         0,
+                         path,
+                         strlen(path) + 1,
+                         0,
+                         0,
+                         0,
+                         0,
+                         &fd);
+  assert(err != UVWASI_ESUCCESS);
+
+  uvwasi_destroy(&uvwasi);
+  free(init_options.preopens);
+
+  return 0;
+}

--- a/test/test-path-resolution.c
+++ b/test/test-path-resolution.c
@@ -148,12 +148,12 @@ int main(void) {
   /* Arguments: input path, expected normalized path */
   check_normalize("", ".");
   check_normalize(".", ".");
-  check_normalize("./", ".");
+  check_normalize("./", "./");
   check_normalize("./.", ".");
   check_normalize("./..", "..");
-  check_normalize("./../", "..");
+  check_normalize("./../", "../");
   check_normalize("..", "..");
-  check_normalize("../", "..");
+  check_normalize("../", "../");
   check_normalize("../.", "..");
   check_normalize("../..", "../..");
   check_normalize("/", "/");
@@ -165,18 +165,18 @@ int main(void) {
   check_normalize("/foo/../bar", "/bar");
   check_normalize("/../bar", "/bar");
   check_normalize("/../../../bar", "/bar");
-  check_normalize("/../../../bar/", "/bar");
+  check_normalize("/../../../bar/", "/bar/");
   check_normalize("/../../../", "/");
   check_normalize("////..//../..///", "/");
-  check_normalize("./foo//", "foo");
+  check_normalize("./foo//", "foo/");
   check_normalize("./foo/////bar", "foo/bar");
   check_normalize("//", "/");
-  check_normalize("..//", "..");
-  check_normalize(".//", ".");
+  check_normalize("..//", "../");
+  check_normalize(".//", "./");
   check_normalize("./foo/bar/baz/../../../..", "..");
-  check_normalize("./foo/bar/baz/../../../../", "..");
+  check_normalize("./foo/bar/baz/../../../../", "../");
   check_normalize("./foo/bar/baz/../../../../..", "../..");
-  check_normalize("./foo/bar/baz/../../../../../", "../..");
+  check_normalize("./foo/bar/baz/../../../../../", "../../");
   check_normalize("../../../test_path", "../../../test_path");
   check_normalize("./././test_path", "test_path");
 


### PR DESCRIPTION
This commit fixes the behavior of `path_open` such that if the path contains trailing slashes and the target file is not a directory, the call errors. This behavior is consistent with Linux host, Wasmtime, WAMR, and WasmEdge.

fixes #267