### PR TITLE
Check result of uvwasi_malloc for NULL

### DIFF
--- a/src/uvwasi.c
+++ b/src/uvwasi.c
@@ -395,6 +395,10 @@ uvwasi_errno_t uvwasi_init(uvwasi_t* uvwasi, const uvwasi_options_t* options) {
 
   if (options->preopen_socketc > 0) {
     uvwasi->loop = uvwasi__malloc(uvwasi, sizeof(uv_loop_t));
+
+    if (uvwasi->loop == NULL)
+      return UVWASI_ENOMEM;
+
     r = uv_loop_init(uvwasi->loop);
     if (r != 0) {
       err = uvwasi__translate_uv_error(r);


### PR DESCRIPTION
In uvwasi_init() function uvwasi_malloc() can return NULL. Need to check return value before dereference.