### PR TITLE
fix: static library name

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -99,6 +99,7 @@ endif()
 
 ## Static library target.
 add_library(uvwasi_a STATIC ${uvwasi_sources})
+set_target_properties(uvwasi_a PROPERTIES OUTPUT_NAME "uvwasi")
 target_compile_definitions(uvwasi_a PRIVATE ${uvwasi_defines})
 target_compile_options(uvwasi_a PRIVATE ${uvwasi_cflags})
 target_include_directories(uvwasi_a PRIVATE ${PROJECT_SOURCE_DIR}/include)


### PR DESCRIPTION
I was getting undefined symbols when trying to build Node.js with shared uvwasi, I think because of the `_a` suffix that gets added to the filename (`lib/libuvwasi_a.a`).