### PR TITLE
chore: update checkout action version to v5

### DIFF
--- a/.github/workflows/Android.yml
+++ b/.github/workflows/Android.yml
@@ -7,7 +7,7 @@ jobs:
     runs-on: ubuntu-latest
     container: reactnativecommunity/react-native-android:7.0
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v5
       - name: Envinfo
         run: npx envinfo
       - name: Build android arm64

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -22,7 +22,7 @@ jobs:
           - os: ubuntu-latest
             config: {variation: 'debug-log', generate_options: '-DUVWASI_DEBUG_LOG=ON -DCMAKE_C_FLAGS="-Wall -Werror"'}
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v5
       - name: Environment Information
         run: npx envinfo
       - name: Build and Test

--- a/.github/workflows/Coverage.yml
+++ b/.github/workflows/Coverage.yml
@@ -9,7 +9,7 @@ jobs:
       matrix:
         os: [ubuntu-latest]
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v5
       - name: Test Coverage
         run: |
           sudo apt update && sudo apt install lcov -y


### PR DESCRIPTION
Last release to checkout v3 is more than three years old.