### PR TITLE
Remove find_dependency for not installed module

### DIFF
--- a/cmake/Config.cmake.in
+++ b/cmake/Config.cmake.in
@@ -1,7 +1,5 @@
 @PACKAGE_INIT@
 include(CMakeFindDependencyMacro)
 
-find_dependency(LibUV)
-
 include("${CMAKE_CURRENT_LIST_DIR}/@target_export_name@.cmake")
 check_required_components("@PROJECT_NAME@")


### PR DESCRIPTION
The `find_dependency` isn't used on standard installations, i.e. find module isn't installed and many repositories don't include CMake config file in libuv (and the upper/lowercase is wrong for either).

At build time, the paths from FindLIBUV are already saved in uvwasiTargets.cmake so this doesn't seem necessary.