### PR TITLE
Add option to skip building shared library

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -6,6 +6,8 @@ project (
     LANGUAGES C
 )
 
+option(UVWASI_BUILD_SHARED "Build shared lib" ON)
+
 # Point CMake at any custom modules we may ship
 list(APPEND CMAKE_MODULE_PATH "${PROJECT_SOURCE_DIR}/cmake")
 
@@ -112,14 +114,16 @@ else()
 endif()
 
 ## Shared library target.
-add_library(uvwasi SHARED ${uvwasi_sources})
-target_compile_definitions(uvwasi PRIVATE ${uvwasi_defines})
-target_compile_options(uvwasi PRIVATE ${uvwasi_cflags})
-target_include_directories(uvwasi PRIVATE ${PROJECT_SOURCE_DIR}/include)
-if(CODE_COVERAGE)
-    target_link_libraries(uvwasi PUBLIC ${LIBUV_LIBRARIES} coverage_config)
-else()
-    target_link_libraries(uvwasi PRIVATE ${LIBUV_LIBRARIES})
+if(UVWASI_BUILD_SHARED)
+    add_library(uvwasi SHARED ${uvwasi_sources})
+    target_compile_definitions(uvwasi PRIVATE ${uvwasi_defines})
+    target_compile_options(uvwasi PRIVATE ${uvwasi_cflags})
+    target_include_directories(uvwasi PRIVATE ${PROJECT_SOURCE_DIR}/include)
+    if(CODE_COVERAGE)
+        target_link_libraries(uvwasi PUBLIC ${LIBUV_LIBRARIES} coverage_config)
+    else()
+        target_link_libraries(uvwasi PRIVATE ${LIBUV_LIBRARIES})
+    endif()
 endif()
 
 


### PR DESCRIPTION
Added `UVWASI_BUILD_SHARED` option, similar to that of libuv ([`LIBUV_BUILD_SHARED`](https://github.com/libuv/libuv/commit/f610339f74f7f0fcd183533d2c965ce1468b44c6)).
I needed to disable the shared library build for some target platforms of [Wasm3](https://github.com/wasm3/wasm3), otherwise the build fails.